### PR TITLE
refactor: 🔄 length => assertLength

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ segments
 2. Iterates over array and saves tuple type
 
 ```ts
-import sta from 'strict-typed-array';
+import sta from "strict-typed-array";
 
 class Segment {
   public bitrate: number = -1;
@@ -45,25 +45,25 @@ class Segment {
 
 const segments: [Segment] = [new Segment()];
 
-const bitrates = segments.map(segment => segment.bitrate);
+const bitrates = segments.map((segment) => segment.bitrate);
 
-bitrates
+bitrates;
 // ^? const bitrates = number[]
 
 // ✅ With strict-typed-array
 
 const bitrates = sta([new Segment()])
-    .map((segment) => segment.bitrate)
-    .toArray();
+  .map((segment) => segment.bitrate)
+  .toArray();
 
-bitrates
+bitrates;
 // ^? const bitrates = [number]
 ```
 
-3. Checks array length and returns array element
+3. Asserts array length and returns array element
 
 ```ts
-import sta from 'strict-typed-array';
+import sta from "strict-typed-array";
 
 class Segment {
   public bitrate: number = -1;
@@ -74,26 +74,26 @@ const segments: Segment[] = [];
 // ❌ Without strict-typed-array
 
 if (segments.length < 1) {
-    throw new Error('Missing segment element');
+  throw new Error("Missing segment element");
 }
 
 const firstSegment = segments[0];
 
-firstSegment
+firstSegment;
 // ^? const firstSegment: Segment | undefined
 
 // ✅ With strict-typed-array
 
 const firstSegment = sta(segments)
-    .length('>= 1', () => new Error('Missing segment element'))
-    .at(0);
+  .assertLength(">= 1", () => new Error("Missing segment element"))
+  .at(0);
 
-firstSegment
+firstSegment;
 // ^? const firstSegment: Segment
 ```
 
 ```ts
-import sta from 'strict-typed-array';
+import sta from "strict-typed-array";
 
 class Segment {
   public bitrate: number = -1;
@@ -104,21 +104,21 @@ const segments: Segment[] = [];
 // ❌ Without strict-typed-array
 
 if (segments.length < 1) {
-    throw new Error('Missing segment element');
+  throw new Error("Missing segment element");
 }
 
 const lastSegment = segments[segments.length - 1];
 
-lastSegment
+lastSegment;
 // ^? const lastSegment: Segment | undefined
 
 // ✅ With strict-typed-array
 
 const lastSegment = sta(segments)
-    .length('>= 1', () => new Error('Missing segment element'))
-    .at(-1);
+  .assertLength(">= 1", () => new Error("Missing segment element"))
+  .at(-1);
 
-lastSegment
+lastSegment;
 // ^? const lastSegment: Segment
 ```
 
@@ -127,8 +127,11 @@ lastSegment
 ```ts
 class StronglyTypedArray<T extends AnyArray> {
   at<N extends number, S extends string = `${N}`>(index: N): Get<T, S>;
-  
-  length<S extends LengthComparison>(condition: S, orThrows: () => Error): StronglyTypedArray<ToTuple<ElementOf<T>, ExtractLength<S>>>;
+
+  length<S extends LengthComparison>(
+    condition: S,
+    orThrows: () => Error
+  ): StronglyTypedArray<ToTuple<ElementOf<T>, ExtractLength<S>>>;
 
   map<U>(
     callback: (value: ElementOf<T>, index: number) => U
@@ -145,5 +148,5 @@ export const sta = <T extends AnyArray>(
 
 ### Supported methods
 
-* `length` (with `>=` comparator)
-* `map`
+- `length` (with `>=` comparator)
+- `map`

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,7 +48,9 @@ type ToTuple<
     >
   : [...T, ...V[], ...T];
 
-type Shift<T extends AnyArray> = T extends [any, ...infer Tail] ? Tail : TupleToArray<T>;
+type Shift<T extends AnyArray> = T extends [any, ...infer Tail]
+  ? Tail
+  : TupleToArray<T>;
 
 type IsTuple<T> = any[] extends T ? false : true;
 
@@ -58,7 +60,9 @@ type ParallelShift<T extends AnyArray, U extends AnyArray> = [] extends U
     : T[0] | undefined
   : ParallelShift<Shift<T>, Shift<U>>;
 
-type Pop<T extends AnyArray> = T extends [...infer Head, any] ? Head : TupleToArray<T>;
+type Pop<T extends AnyArray> = T extends [...infer Head, any]
+  ? Head
+  : TupleToArray<T>;
 
 type ParallelPop<T extends AnyArray, U extends AnyArray> = [] extends U
   ? IsTuple<T> extends true
@@ -69,14 +73,16 @@ type ParallelPop<T extends AnyArray, U extends AnyArray> = [] extends U
 type Get<T extends AnyArray, N extends string> = N extends `-${infer M}`
   ? ParallelPop<[ElementOf<T>, ...T, ElementOf<T>], ToTuple<ElementOf<T>, M>>
   : N extends `${number}`
-    ? ParallelShift<T, ToTuple<ElementOf<T>, N>>
-    : never;
+  ? ParallelShift<T, ToTuple<ElementOf<T>, N>>
+  : never;
 
 type TupleToArray<T extends AnyArray> = ElementOf<T>[];
 
 type LengthComparison = `>= ${number}`;
 
-type ExtractLength<S extends LengthComparison> = S extends `>= ${infer N}` ? `${N}` : `${number}`;
+type ExtractLength<S extends LengthComparison> = S extends `>= ${infer N}`
+  ? `${N}`
+  : `${number}`;
 
 class StronglyTypedArray<T extends AnyArray> {
   #items: T;
@@ -85,11 +91,16 @@ class StronglyTypedArray<T extends AnyArray> {
     this.#items = items;
   }
 
-  length<S extends LengthComparison>(condition: S, orThrows: () => Error): StronglyTypedArray<ToTuple<ElementOf<T>, ExtractLength<S>>> {
-    const expectedLength = Number(condition.split(' ')[1]);
-    
+  assertLength<S extends LengthComparison>(
+    condition: S,
+    orThrows: () => Error
+  ): StronglyTypedArray<ToTuple<ElementOf<T>, ExtractLength<S>>> {
+    const expectedLength = Number(condition.split(" ")[1]);
+
     if (this.#items.length >= expectedLength) {
-      return this as unknown as StronglyTypedArray<ToTuple<ElementOf<T>, ExtractLength<S>>>
+      return this as unknown as StronglyTypedArray<
+        ToTuple<ElementOf<T>, ExtractLength<S>>
+      >;
     }
 
     throw orThrows();

--- a/type/assert-length.type.ts
+++ b/type/assert-length.type.ts
@@ -6,37 +6,40 @@ declare const numbers: number[];
 const staNumbers = sta(numbers);
 
 const sameNumbers = staNumbers
-  .length(">= 0", () => new Error("Length cannot be negative"))
+  .assertLength(">= 0", () => new Error("Length cannot be negative"))
   .toArray();
 const numbers1 = staNumbers
-  .length(">= 1", () => new Error("Expected to have at least 1 element"))
+  .assertLength(">= 1", () => new Error("Expected to have at least 1 element"))
   .toArray();
 const numbers2 = staNumbers
-  .length(">= 2", () => new Error("Expected to have at least 2 element"))
+  .assertLength(">= 2", () => new Error("Expected to have at least 2 element"))
   .toArray();
 const numbers3 = staNumbers
-  .length(">= 3", () => new Error("Expected to have at least 3 element"))
+  .assertLength(">= 3", () => new Error("Expected to have at least 3 element"))
   .toArray();
 const numbers4 = staNumbers
-  .length(">= 4", () => new Error("Expected to have at least 4 element"))
+  .assertLength(">= 4", () => new Error("Expected to have at least 4 element"))
   .toArray();
 const numbers5 = staNumbers
-  .length(">= 5", () => new Error("Expected to have at least 5 element"))
+  .assertLength(">= 5", () => new Error("Expected to have at least 5 element"))
   .toArray();
 const numbers6 = staNumbers
-  .length(">= 6", () => new Error("Expected to have at least 6 element"))
+  .assertLength(">= 6", () => new Error("Expected to have at least 6 element"))
   .toArray();
 const numbers7 = staNumbers
-  .length(">= 7", () => new Error("Expected to have at least 7 element"))
+  .assertLength(">= 7", () => new Error("Expected to have at least 7 element"))
   .toArray();
 const numbers8 = staNumbers
-  .length(">= 8", () => new Error("Expected to have at least 8 element"))
+  .assertLength(">= 8", () => new Error("Expected to have at least 8 element"))
   .toArray();
 const numbers9 = staNumbers
-  .length(">= 9", () => new Error("Expected to have at least 9 element"))
+  .assertLength(">= 9", () => new Error("Expected to have at least 9 element"))
   .toArray();
 const numbers10 = staNumbers
-  .length(">= 10", () => new Error("Expected to have at least 10 element"))
+  .assertLength(
+    ">= 10",
+    () => new Error("Expected to have at least 10 element")
+  )
   .toArray();
 
 type cases = [

--- a/type/at.type.ts
+++ b/type/at.type.ts
@@ -6,28 +6,28 @@ declare const numbers: number[];
 const staNumbers = sta(numbers);
 
 const firstOptional = staNumbers
-  .length(">= 0", () => new Error("Length cannot be negative"))
+  .assertLength(">= 0", () => new Error("Length cannot be negative"))
   .at(0);
 const first = staNumbers
-  .length(">= 1", () => new Error("Missing elements"))
+  .assertLength(">= 1", () => new Error("Missing elements"))
   .at(0);
 const secondOptional = staNumbers
-  .length(">= 1", () => new Error("Missing elements"))
+  .assertLength(">= 1", () => new Error("Missing elements"))
   .at(1);
 const second = staNumbers
-  .length(">= 2", () => new Error("Missing elements"))
+  .assertLength(">= 2", () => new Error("Missing elements"))
   .at(1);
 const beforeLastOptional = staNumbers
-  .length(">= 1", () => new Error("Missing elements"))
+  .assertLength(">= 1", () => new Error("Missing elements"))
   .at(-2);
 const beforeLast = staNumbers
-  .length(">= 2", () => new Error("Missing elements"))
+  .assertLength(">= 2", () => new Error("Missing elements"))
   .at(-2);
 const lastOptional = staNumbers
-  .length(">= 0", () => new Error("Length cannot be negative"))
+  .assertLength(">= 0", () => new Error("Length cannot be negative"))
   .at(-1);
 const last = staNumbers
-  .length(">= 1", () => new Error("Missing elements"))
+  .assertLength(">= 1", () => new Error("Missing elements"))
   .at(-1);
 
 type cases = [


### PR DESCRIPTION
## What

Rename `length` to `assertLength`

## Why

I leave `length` for just checking the length